### PR TITLE
Camelcase stark public key parameter

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -259,7 +259,7 @@ export class StarkwareController {
           id,
           result: await this.register(
             params.contractAddress,
-            params.StarkPublicKey,
+            params.starkPublicKey,
             params.operatorSignature
           ),
         };
@@ -269,7 +269,7 @@ export class StarkwareController {
           id,
           result: await this.deposit(
             params.contractAddress,
-            params.StarkPublicKey,
+            params.starkPublicKey,
             params.quantizedAmount,
             params.token,
             params.vaultId
@@ -281,7 +281,7 @@ export class StarkwareController {
           id,
           result: await this.depositCancel(
             params.contractAddress,
-            params.StarkPublicKey,
+            params.starkPublicKey,
             params.token,
             params.vaultId
           ),
@@ -292,7 +292,7 @@ export class StarkwareController {
           id,
           result: await this.depositReclaim(
             params.contractAddress,
-            params.StarkPublicKey,
+            params.starkPublicKey,
             params.token,
             params.vaultId
           ),


### PR DESCRIPTION
The stark public key parameter should be camelcased to match JSON RPC spec: https://hackmd.io/4XaD-LTeTLWGaNG-h-KHWA?view#Register-Account

The starkware provider sends it correctly but the controller is unable to resolve it because the casing is incorrect

https://github.com/pedrouid/starkware-provider/blob/0fd855af270b1a0ab087f3960e6e94dacb9f4893/src/provider.ts#L116