### PR TITLE
Use provider with signer for contract instance

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -407,8 +407,7 @@ export class StarkwareController {
   }
 
   private getExchangeContract(contractAddress: string) {
-    const provider = this.wallet.provider;
-    return new ethers.Contract(contractAddress, abi, provider);
+    return new ethers.Contract(contractAddress, abi, this.wallet);
   }
 
   private async getAccountMapping(): Promise<StarkwareAccountMapping> {


### PR DESCRIPTION
Using `this.wallet.provider` only allows calling constant functions causing the error `sending a transaction requires a signer` when calling the register function so the contract instance should use `this.wallet` which includes the signer. 